### PR TITLE
Sort events based on date

### DIFF
--- a/_src/_events/2014-11-12-a-video-post.markdown
+++ b/_src/_events/2014-11-12-a-video-post.markdown
@@ -1,7 +1,7 @@
 ---
 layout:      event
 title:       "A Video Post"
-date:        2014-11-12 10:36:06
+date:        2016-11-12 10:36:06
 categories:  talk video
 icon_type:   videocamera
 description: A recording of a talk.

--- a/_src/events.html
+++ b/_src/events.html
@@ -5,7 +5,8 @@ layout: page
 <div class="measure">
   <h1>Events</h1>
   <ul class="list">
-    {% for event in site.events reversed %}
+    {% assign events = site.events | sort: 'date' %}
+    {% for event in events reversed %}
       <li class="list-item">
         <a href="{{event.url | prepend: site.baseurl}}" title="{{event.title}}">
           <h3 class="list-item-title">


### PR DESCRIPTION
For whatever reason, Jekyll doesn't seem to like piping after sorting. Unfortunately,
we want the sort order to be reverse chronological. In order to get around this I
first assign the `events` variable to the chronological ordering with `sort: 'date'`,
and then specify `reversed` when iterating over `events` within the `for` loop.

I've also modified a date on an event to ensure that the ordering is working
as intended.
