### PR TITLE
Map each icon to multiple types of posts and events

### DIFF
--- a/_src/_events/2014-11-12-a-video-post.markdown
+++ b/_src/_events/2014-11-12-a-video-post.markdown
@@ -2,8 +2,8 @@
 layout:      event
 title:       "A Video Post"
 date:        2014-11-12 10:36:06
-categories:  talk video
-icon_type:   videocamera
+categories:
+  - video
 description: A recording of a talk.
 ---
 

--- a/_src/_events/2014-11-17-trip-to-the-north-pole.markdown
+++ b/_src/_events/2014-11-17-trip-to-the-north-pole.markdown
@@ -2,8 +2,9 @@
 layout:      event
 title:       "Trip to the North Pole with Another Really Long Title"
 date:        2014-11-17 10:36:06
-categories:  talk
-icon_type:   plane
+categories:
+  - trip
+  - special event
 description: Headed to the North Pole for a conference on present wrapping.
 ---
 

--- a/_src/_events/2015-01-2-a-class-post.markdown
+++ b/_src/_events/2015-01-2-a-class-post.markdown
@@ -2,8 +2,10 @@
 layout:      event
 title:       "A Class Post"
 date:        2015-01-02 10:36:06
-categories:  class talk lecture
-icon_type:   professor
+categories:
+  - class
+  - talk
+  - lecture
 description: A lecture on stuff.
 ---
 

--- a/_src/_includes/event-list-compact.html
+++ b/_src/_includes/event-list-compact.html
@@ -6,7 +6,7 @@
 
   <ul class="list">
     {% for event in site.events reversed limit:3 %}
-      {% include list-item-compact.html title=event.title url=event.url date=event.date icon_type=event.icon_type %}
+      {% include list-item-compact.html list_item=event %}
     {% endfor %}
   </ul>
 </div>

--- a/_src/_includes/icon.html
+++ b/_src/_includes/icon.html
@@ -1,0 +1,15 @@
+{% if 'link' contains include.icon_type %}
+  <i class="jf-i-link"></i>
+{% elsif 'file blog post writing essay' contains include.icon_type %}
+  <i class="jf-i-file"></i>
+{% elsif 'plane travel trip' contains include.icon_type %}
+  <i class="jf-i-plane"></i>
+{% elsif 'comment' contains include.icon_type %}
+  <i class="jf-i-comment"></i>
+{% elsif 'professor talk speaking' contains include.icon_type %}
+  <i class="jf-i-professor"></i>
+{% elsif 'videocamera video film' contains include.icon_type %}
+  <i class="jf-i-videocamera"></i>
+{% else %}
+  Please see _src/_includes/icon.html to see the correct icon types.
+{% endif %}

--- a/_src/_includes/icon.html
+++ b/_src/_includes/icon.html
@@ -1,15 +1,18 @@
-{% if 'link' contains include.icon_type %}
+{% assign icon_type = include.post_or_event.categories[0] %}
+
+{% if 'link' contains icon_type %}
   <i class="jf-i-link"></i>
-{% elsif 'file blog post writing essay' contains include.icon_type %}
+{% elsif 'file blog post writing essay' contains icon_type %}
   <i class="jf-i-file"></i>
-{% elsif 'plane travel trip' contains include.icon_type %}
+{% elsif 'plane travel trip' contains icon_type %}
   <i class="jf-i-plane"></i>
-{% elsif 'comment' contains include.icon_type %}
+{% elsif 'comment comments' contains icon_type %}
   <i class="jf-i-comment"></i>
-{% elsif 'professor talk speaking' contains include.icon_type %}
+{% elsif 'professor talk speaking class' contains icon_type %}
   <i class="jf-i-professor"></i>
-{% elsif 'videocamera video film' contains include.icon_type %}
+{% elsif 'videocamera video film' contains icon_type %}
   <i class="jf-i-videocamera"></i>
 {% else %}
+  {{icon_type}} doesn't have a mapping. <br>
   Please see _src/_includes/icon.html to see the correct icon types.
 {% endif %}

--- a/_src/_includes/list-item-compact.html
+++ b/_src/_includes/list-item-compact.html
@@ -4,13 +4,13 @@
       <div class="media-object-figure">
         <h4 class="m0">
           <small>
-            {% include list-item-meta.html icon_type=include.icon_type date=include.date %}
+            {% include list-item-meta.html list_item=include.list_item %}
           </small>
         </h4>
       </div>
       <div class="media-object-body">
         <h4 class="m0">
-          {{include.title}}
+          {{include.list_item.title}}
         </h4>
       </div>
     </div>

--- a/_src/_includes/list-item-meta.html
+++ b/_src/_includes/list-item-meta.html
@@ -1,4 +1,4 @@
 <span class="muted">
-  <i class="jf-i-{% if include.icon_type %}{{include.icon_type}}{% else %}file{% endif %}"></i> &nbsp;
+  {% include icon.html icon_type=include.icon_type %} &nbsp;
   {% include short-date.html date=include.date %}
 </span>

--- a/_src/_includes/list-item-meta.html
+++ b/_src/_includes/list-item-meta.html
@@ -1,4 +1,4 @@
 <span class="muted">
-  {% include icon.html icon_type=include.icon_type %} &nbsp;
-  {% include short-date.html date=include.date %}
+  {% include icon.html post_or_event=include.list_item %} &nbsp;
+  {% include short-date.html date=include.list_item.date %}
 </span>

--- a/_src/_includes/post-list-compact.html
+++ b/_src/_includes/post-list-compact.html
@@ -6,7 +6,7 @@
 
   <ul class="list">
     {% for post in site.posts limit:3 %}
-      {% include list-item-compact.html title=post.title url=post.url date=post.date icon_type=post.icon_type %}
+      {% include list-item-compact.html list_item=post %}
     {% endfor %}
   </ul>
 </div>

--- a/_src/_includes/post-list-item.html
+++ b/_src/_includes/post-list-item.html
@@ -3,7 +3,7 @@
     <div class="media-object-figure mr1 txt--right">
       <h3 class="list-item-title">
         <a href="{{include.post.url | prepend: site.baseurl}}" title="{{include.post.title}}">
-          <i class="jf-i-{% if include.post.icon_type %}{{include.post.icon_type}}{% else %}file{% endif %}"></i>
+          {% include icon.html icon_type=include.post.icon_type %}
         </a>
       </h3>
       <div class="muted--2x">

--- a/_src/_includes/post-list-item.html
+++ b/_src/_includes/post-list-item.html
@@ -3,7 +3,7 @@
     <div class="media-object-figure mr1 txt--right">
       <h3 class="list-item-title">
         <a href="{{include.post.url | prepend: site.baseurl}}" title="{{include.post.title}}">
-          {% include icon.html icon_type=include.post.icon_type %}
+          {% include icon.html post_or_event=post %}
         </a>
       </h3>
       <div class="muted--2x">

--- a/_src/_posts/2014-11-01-a-comment-post.markdown
+++ b/_src/_posts/2014-11-01-a-comment-post.markdown
@@ -3,7 +3,6 @@ layout:        post
 title:         "A Comment Post"
 date:          2014-11-08 12:36:06
 tags:          comment ruby
-icon_type:     comment
 categories:    comments
 nav_highlight: blog
 description:   A comment on something regarding Ruby.

--- a/_src/_posts/2014-11-08-welcome-to-jekyll.markdown
+++ b/_src/_posts/2014-11-08-welcome-to-jekyll.markdown
@@ -3,8 +3,8 @@ layout:        post
 title:         "Welcome to Jekyll!"
 date:          2014-11-08 12:36:06
 tags:          jekyll update
-icon_type:     link
 nav_highlight: blog
+categories:    link description
 description:   A short introduction and primer for Jekyll, a static site generator.
 ---
 

--- a/_src/_posts/2014-11-09-see-everything-in-action.markdown
+++ b/_src/_posts/2014-11-09-see-everything-in-action.markdown
@@ -3,6 +3,7 @@ layout:        post
 title:         See Everything in Action with a Really Long Post Title
 date:          2014-11-09 12:36:06
 nav_highlight: blog
+icon_type:     post
 description:   See what the different elements looks like. Your markdown has never looked better. I promise.
 tags:          jekyll pixyll
 ---

--- a/_src/_posts/2014-11-09-see-everything-in-action.markdown
+++ b/_src/_posts/2014-11-09-see-everything-in-action.markdown
@@ -3,7 +3,7 @@ layout:        post
 title:         See Everything in Action with a Really Long Post Title
 date:          2014-11-09 12:36:06
 nav_highlight: blog
-icon_type:     post
+categories:    blog
 description:   See what the different elements looks like. Your markdown has never looked better. I promise.
 tags:          jekyll pixyll
 ---


### PR DESCRIPTION
This breaks out the icon into it's own include where a string of enumerated
post types is checked to see whether it contains the icon type. If no match
is made, a help message is instead displayed.

In order to clean up some logic, the list-item includes now pass along the
object rather than attributes. This allowed the categories to be accessible
from the icon partial.

The events required an additional tweak, too. Since they're a collection
rather than a post, a whitespace separated string returned the entire
string rather than an array split on the whitespace which occurs on
posts. As such, I modified the event front matter to now have YAML arrays.
