### PR TITLE
Added sidenotes

### DIFF
--- a/_src/_config.yml
+++ b/_src/_config.yml
@@ -38,6 +38,7 @@ markdown:     kramdown
 kramdown:
   input: GFM
   syntax_highlighter: rouge
+  hard_wrap: false
 
 exclude:     ['node_modules', 'gulpfile.js', 'package.json', 'Gemfile', 'Gemfile.lock', 'divshot.json', '.divshot-cache']
 

--- a/_src/_entries/000009-entry-tufte-css-test.markdown
+++ b/_src/_entries/000009-entry-tufte-css-test.markdown
@@ -1,0 +1,17 @@
+---
+type:         post
+title:        "Tufte-CSS Test"
+date:         2016-03-14T10:00:00Z
+published:    false
+tags:
+  - pivotal
+  - work
+description: >
+  Tufte-CSS Test
+---
+
+Tufte CSS provides tools to style web articles using the ideas demonstrated by Edward Tufte’s books and handouts. Tufte’s style is known for its simplicity, extensive use of sidenotes, tight integration of graphics with text, and carefully chosen typography.
+
+# Side Notes
+
+One of the most distinctive features of Tufte’s style is his extensive use of sidenotes.{% include sidenote.html reference="sidenote-example" content="This is a sidenote." %} Sidenotes are like footnotes, except they don’t force the reader to jump their eye to the bottom of the page, but instead display off to the side in the margin. Perhaps you have noticed their use in this document already. You are very astute.

--- a/_src/_includes/sidenote.html
+++ b/_src/_includes/sidenote.html
@@ -1,1 +1,7 @@
-<label for="{{ include.reference }}" class="margin-toggle sidenote-number"></label><input type="checkbox" id="{{ include.reference }}" class="margin-toggle"/><span class="sidenote">{{ include.content }}</span>
+{% capture workaround %}
+	{% assign sidenote-counter = sidenote-counter | plus: 1 %}
+	{% assign sidenote-string = 'sidenote-' | append:sidenote-counter %}
+{% endcapture %}{% assign workaround = nil %}
+<label for="{{ include.reference | default: sidenote-string }}" class="margin-toggle sidenote-number"></label>
+<input type="checkbox" id="{{ include.reference | default: sidenote-string }}" class="margin-toggle"/>
+<span class="sidenote">{{ include.content }}</span>

--- a/_src/_includes/sidenote.html
+++ b/_src/_includes/sidenote.html
@@ -1,0 +1,1 @@
+<label for="{{ include.reference }}" class="margin-toggle sidenote-number"></label><input type="checkbox" id="{{ include.reference }}" class="margin-toggle"/><span class="sidenote">{{ include.content }}</span>

--- a/_src/_scss/all.scss
+++ b/_src/_scss/all.scss
@@ -28,3 +28,4 @@
 @import "partials/code-blocks";
 @import "partials/blockquotes";
 @import "partials/syntax-highlighting";
+@import "partials/tufte";

--- a/_src/_scss/partials/_tufte.scss
+++ b/_src/_scss/partials/_tufte.scss
@@ -1,0 +1,79 @@
+input.margin-toggle { 
+    display: none; 
+}
+
+label.sidenote-number { 
+    display: inline; 
+}
+
+label.margin-toggle:not(.sidenote-number) { 
+    display: none; 
+}
+
+//Sidenote styling
+.sidenote, 
+.marginnote { 
+    float: right;
+    clear: right;
+    margin-right: -60%;
+    width: 50%;
+    margin-top: 0;
+    margin-bottom: 0;
+    font-family: $serif-font-family;
+    font-size: 0.88rem;
+    opacity: 0.75;
+    vertical-align: baseline;
+    position: relative;
+}
+
+.sidenote-number { 
+	counter-increment: sidenote-counter; 
+}
+
+.sidenote-number:after, 
+.sidenote:before { 
+	content: counter(sidenote-counter) " ";
+    position: relative;
+    vertical-align: baseline;
+    font-family: $serif-font-family;
+    font-size: 0.88rem;
+}
+
+//The sidenote number in margin
+.sidenote-number:after { 
+	content: counter(sidenote-counter);
+    font-size: 1rem;
+    top: -0.5rem;
+    left: 0.1rem; }
+
+//The sidenote number in paragraph
+.sidenote:before { 
+	content: counter(sidenote-counter) " ";
+    top: -0.5rem; 
+    opacity: 0.75;
+}
+
+//Tufte-CSS Responsive Sidenote & Margins
+//At small widths, sidenote will be hidden by default, but togglable to show/hide
+@media (max-width: 760px) { 
+  label.margin-toggle:not(.sidenote-number) { 
+        display: inline; 
+    }
+    .sidenote, .marginnote { 
+        display: none; 
+    }
+    .margin-toggle:checked + .sidenote,
+    .margin-toggle:checked + .marginnote { 
+        display: block;
+        float: left;
+        left: 1rem;
+        clear: both;
+        width: 95%;
+        margin: 1rem 2.5%;
+        vertical-align: baseline;
+        position: relative; 
+    }
+    label { 
+        cursor: pointer; 
+    }
+}

--- a/_src/_scss/partials/_tufte.scss
+++ b/_src/_scss/partials/_tufte.scss
@@ -1,79 +1,78 @@
+body {
+  counter-reset: sidenote-counter;
+}
+
 input.margin-toggle { 
-    display: none; 
+  display: none; 
 }
 
 label.sidenote-number { 
-    display: inline; 
+  display: inline; 
 }
 
 label.margin-toggle:not(.sidenote-number) { 
-    display: none; 
+  display: none; 
 }
 
-//Sidenote styling
-.sidenote, 
+.sidenote,
 .marginnote { 
-    float: right;
-    clear: right;
-    margin-right: -60%;
-    width: 50%;
-    margin-top: 0;
-    margin-bottom: 0;
-    font-family: $serif-font-family;
-    font-size: 0.88rem;
-    opacity: 0.75;
-    vertical-align: baseline;
-    position: relative;
+  float: right;
+  clear: right;
+  margin-right: -60%;
+  width: 50%;
+  margin-top: 0;
+  margin-bottom: 0;
+  font-family: $serif-font-family;
+  font-size: 0.88rem;
+  opacity: 0.75;
+  vertical-align: baseline;
+  position: relative;
 }
 
 .sidenote-number { 
-	counter-increment: sidenote-counter; 
+  counter-increment: sidenote-counter; 
 }
 
-.sidenote-number:after, 
+.sidenote-number:after,
 .sidenote:before { 
-	content: counter(sidenote-counter) " ";
-    position: relative;
-    vertical-align: baseline;
-    font-family: $serif-font-family;
-    font-size: 0.88rem;
+  content: counter(sidenote-counter) " ";
+  position: relative;
+  vertical-align: baseline;
+  font-family: $serif-font-family;
+  font-size: 0.88rem;
 }
 
-//The sidenote number in margin
 .sidenote-number:after { 
-	content: counter(sidenote-counter);
-    font-size: 1rem;
-    top: -0.5rem;
-    left: 0.1rem; }
+  content: counter(sidenote-counter);
+  font-size: 1rem;
+  top: -0.5rem;
+  left: -0.15rem; }
 
-//The sidenote number in paragraph
 .sidenote:before { 
-	content: counter(sidenote-counter) " ";
-    top: -0.5rem; 
-    opacity: 0.75;
+  content: counter(sidenote-counter) " ";
+  top: -0.5rem; 
+  opacity: 0.75;
 }
 
-//Tufte-CSS Responsive Sidenote & Margins
-//At small widths, sidenote will be hidden by default, but togglable to show/hide
 @media (max-width: 760px) { 
   label.margin-toggle:not(.sidenote-number) { 
-        display: inline; 
-    }
-    .sidenote, .marginnote { 
-        display: none; 
-    }
-    .margin-toggle:checked + .sidenote,
-    .margin-toggle:checked + .marginnote { 
-        display: block;
-        float: left;
-        left: 1rem;
-        clear: both;
-        width: 95%;
-        margin: 1rem 2.5%;
-        vertical-align: baseline;
-        position: relative; 
-    }
-    label { 
-        cursor: pointer; 
-    }
+    display: inline; 
+  }
+  .sidenote, .marginnote { 
+    display: none; 
+  }
+  .margin-toggle:checked + .sidenote,
+  .margin-toggle:checked + .marginnote { 
+    display: block;
+    float: left;
+    left: 1rem;
+    clear: both;
+    width: 95%;
+    margin: 1rem 2.5%;
+    vertical-align: baseline;
+    position: relative; 
+  }
+  label { 
+    cursor: pointer; 
+  }
 }


### PR DESCRIPTION
Mimicked the sidenotes from Tufte-CSS: at small widths, sidenote will be hidden by default, but togglable to show/hide

I've thought of several way to implement sidenotes into Markdown and I came up with a solution using Liquid templating. At any place in a paragraph, you can enter a sidenote like this:

`{% include sidenote.html reference="sidenote-example" content="This is a sidenote." %}`

Each sidenote needs a unique `reference`. It is for the `id` and `for` attributes in HTML. Although it is possible to automate the reference with CSS Counter, it is better to give it a good name for screen readers for the visually impaired.

---

I've included a test entry. Its `published` is set to false.
