### PR TITLE
Added marginnotes include file

### DIFF
--- a/_src/_entries/000009-entry-tufte-css-test.markdown
+++ b/_src/_entries/000009-entry-tufte-css-test.markdown
@@ -2,7 +2,7 @@
 type:         post
 title:        "Tufte-CSS Test"
 date:         2016-03-14T10:00:00Z
-published:    false
+published:    true
 tags:
   - pivotal
   - work
@@ -14,4 +14,21 @@ Tufte CSS provides tools to style web articles using the ideas demonstrated by E
 
 # Side Notes
 
-One of the most distinctive features of Tufte’s style is his extensive use of sidenotes.{% include sidenote.html reference="sidenote-example" content="This is a sidenote." %} Sidenotes are like footnotes, except they don’t force the reader to jump their eye to the bottom of the page, but instead display off to the side in the margin. Perhaps you have noticed their use in this document already. You are very astute.
+One of the most distinctive features of Tufte’s style is his extensive use of sidenotes.{% sidenote %}This is a sidenote."{% endsidenote %} Sidenotes are like footnotes, except they don’t force the reader to jump their eye to the bottom of the page, but instead display off to the side in the margin.{% sidenote test-ref%}This is a sidenote with a **custom reference**."{% endsidenote %} Perhaps you have noticed their use in this document already.
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit.{% sidenote %}This is another sidenote *without* a reference to demonstrate that it is optional{% endsidenote %} Eaque quo aspernatur dolor sed voluptate repudiandae inventore deleniti commodi reprehenderit fugit, animi doloremque obcaecati, dolores debitis, quis porro? Assumenda, nisi, tenetur!
+
+# Margin Notes
+
+If you want a sidenote without footnote-style numberings, then you want a margin note.{% margin %}This is a margin note{% endmargin %} Notice there isn’t a number preceding the note. On large screens, a margin note is just a sidenote that omits the reference number. This lessens the distracting effect taking away from the flow of the main text, but can increase the cognitive load of matching a margin note to its referent text. However, on small screens, a margin note is like a sidenote except its viewability-toggle is a symbol rather than a reference number. This document currently uses the symbol ⊕ (&#8853;), but it’s up to you.
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ut eligendi, aut earum in sapiente a laboriosam impedit cupiditate quos quam laudantium, delectus possimus.{% margin %}This is another margin note{% endmargin %}
+
+# Margin Notes With Images and HTML
+
+Tufte emphasizes tight integration of graphics with text. Data, graphs, and figures are kept with the text that discusses them. In print, this means they are not relegated to a separate page. On the web, that means readability of graphics and their accompanying text without extra clicks, tab-switching, or scrolling.
+
+{% margin %}
+<img src="https://edwardtufte.github.io/tufte-css/img/rhino.png" alt="Image of a Rhinoceros"/>F.J. Cole, “The History of Albrecht Dürer’s Rhinoceros in Zooological Literature,” <em>Science, Medicine, and History: Essays on the Evolution of Scientific Thought and Medical Practice</em> (London, 1953), ed. E. Ashworth Underwood, 337-356. From page 71 of Edward Tufte’s <em>Visual Explanations</em>.
+{% endmargin %}
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Labore facilis ipsa optio modi, voluptate temporibus impedit perferendis vitae recusandae quidem, explicabo laudantium at dolorem beatae illum est fuga voluptatibus quis error dignissimos illo accusamus vel incidunt vero cumque? Ipsum recusandae culpa est ratione nulla voluptatum rerum assumenda deserunt eum perspiciatis!

--- a/_src/_includes/marginnotes.html
+++ b/_src/_includes/marginnotes.html
@@ -1,7 +1,0 @@
-{% capture workaround %}
-	{% assign marginnote-counter = marginnote-counter | plus: 1 %}
-	{% assign marginnote-string = 'marginnote-' | append:marginnote-counter %}
-{% endcapture %}{% assign workaround = nil %}
-<label for="{{ include.reference | default: sidenote-string }}" class="margin-toggle">&#8853;</label>
-<input type="checkbox" id="{{ include.reference | default: sidenote-string }}" class="margin-toggle"/>
-<span class="marginnote">{{ include.content }}</span>

--- a/_src/_includes/marginnotes.html
+++ b/_src/_includes/marginnotes.html
@@ -1,0 +1,7 @@
+{% capture workaround %}
+	{% assign marginnote-counter = marginnote-counter | plus: 1 %}
+	{% assign marginnote-string = 'marginnote-' | append:marginnote-counter %}
+{% endcapture %}{% assign workaround = nil %}
+<label for="{{ include.reference | default: sidenote-string }}" class="margin-toggle">&#8853;</label>
+<input type="checkbox" id="{{ include.reference | default: sidenote-string }}" class="margin-toggle"/>
+<span class="marginnote">{{ include.content }}</span>

--- a/_src/_includes/sidenote.html
+++ b/_src/_includes/sidenote.html
@@ -1,7 +1,0 @@
-{% capture workaround %}
-	{% assign sidenote-counter = sidenote-counter | plus: 1 %}
-	{% assign sidenote-string = 'sidenote-' | append:sidenote-counter %}
-{% endcapture %}{% assign workaround = nil %}
-<label for="{{ include.reference | default: sidenote-string }}" class="margin-toggle sidenote-number"></label>
-<input type="checkbox" id="{{ include.reference | default: sidenote-string }}" class="margin-toggle"/>
-<span class="sidenote">{{ include.content }}</span>

--- a/_src/_plugins/tufte.rb
+++ b/_src/_plugins/tufte.rb
@@ -1,18 +1,20 @@
 module Jekyll
   class MarginNotes < Liquid::Block
     alias_method :render_block, :render
-    @@margincount = 0;
+    @@margincount = Hash.new(0)
 
     def initialize(tag_name, reference, tokens)
       super
       @reference = reference
-      @@margincount += 1;
-      if @reference !~ /[^[:space:]]/
-        @reference = "marginnote-#{@@margincount}";
-      end
     end
 
     def render(context)
+      # If reference is not manually set, use the automatic increment system
+      page_url = context.environments.first["page"]["url"]
+      @@margincount[page_url] += 1
+      if @reference !~ /[^[:space:]]/
+        @reference = "marginnote-#{@@margincount[page_url]}"
+      end
       site = context.registers[:site]
       converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
       content = converter.convert(super(context))
@@ -24,18 +26,20 @@ module Jekyll
 
   class SideNotes < Liquid::Block
     alias_method :render_block, :render
-    @@sidenotecount = 0;
+    @@sidenotecount = Hash.new(0)
 
     def initialize(tag_name, reference, tokens)
       super
       @reference = reference
-      @@sidenotecount += 1;
-      if @reference !~ /[^[:space:]]/
-        @reference = "sidenote-#{@@sidenotecount}";
-      end
     end
 
     def render(context)
+      # If reference is not manually set, use the automatic increment system
+      page_url = context.environments.first["page"]["url"]
+      @@sidenotecount[page_url] += 1
+      if @reference !~ /[^[:space:]]/
+        @reference = "sidenote-#{@@sidenotecount[page_url]}"
+      end
       site = context.registers[:site]
       converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
       content = converter.convert(super(context))

--- a/_src/_plugins/tufte.rb
+++ b/_src/_plugins/tufte.rb
@@ -1,0 +1,50 @@
+module Jekyll
+  class MarginNotes < Liquid::Block
+    alias_method :render_block, :render
+    @@margincount = 0;
+
+    def initialize(tag_name, reference, tokens)
+      super
+      @reference = reference
+      @@margincount += 1;
+      if @reference !~ /[^[:space:]]/
+        @reference = "marginnote-#{@@margincount}";
+      end
+    end
+
+    def render(context)
+      site = context.registers[:site]
+      converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+      content = converter.convert(super(context))
+      content.gsub! '<p>', ''
+      content.gsub! '</p>', ''
+      "<label for=\"#{@reference}\" class=\"margin-toggle\">&#8853;</label><input type=\"checkbox\" id=\"#{@reference}\" class=\"margin-toggle\"/><span class=\"marginnote\">#{content}</span>"
+    end
+  end
+
+  class SideNotes < Liquid::Block
+    alias_method :render_block, :render
+    @@sidenotecount = 0;
+
+    def initialize(tag_name, reference, tokens)
+      super
+      @reference = reference
+      @@sidenotecount += 1;
+      if @reference !~ /[^[:space:]]/
+        @reference = "sidenote-#{@@sidenotecount}";
+      end
+    end
+
+    def render(context)
+      site = context.registers[:site]
+      converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+      content = converter.convert(super(context))
+      content.gsub! '<p>', ''
+      content.gsub! '</p>', ''
+      "<label for=\"#{@reference}\" class=\"margin-toggle sidenote-number\"></label><input type=\"checkbox\" id=\"#{@reference}\" class=\"margin-toggle sidenote-number\"/><span class=\"sidenote\">#{content}</span>"
+    end
+  end
+end
+
+Liquid::Template.register_tag('margin', Jekyll::MarginNotes)
+Liquid::Template.register_tag('sidenote', Jekyll::SideNotes)


### PR DESCRIPTION
Implementation in Markdown is similar to sidenotes:

```
{% include marginnotes.html content="Here is a margin note." %} `
```

```
{% include marginnotes.html reference="marginnote-reference" content="Here is another margin note. This one has a <em>custom reference</em>" %}
```
