### PR TITLE
YYYY-MM-DD dates in shortlists on homepage

### DIFF
--- a/_src/_includes/list-item-meta.html
+++ b/_src/_includes/list-item-meta.html
@@ -1,4 +1,4 @@
 <span class="muted">
   {% include icon.html post_or_event=include.list_item %} &nbsp;
-  {% include short-date.html date=include.list_item.date %}
+  {% include number-date.html date=include.list_item.date %}
 </span>

--- a/_src/_includes/number-date.html
+++ b/_src/_includes/number-date.html
@@ -1,0 +1,3 @@
+<time datetime="{{include.date}}" title="{{include.date | date: '%m-%d-%y @ %T'}}">
+  {{include.date | date: "%Y-%m-%d"}}
+</time>

--- a/_src/_scss/components/_media-object.scss
+++ b/_src/_scss/components/_media-object.scss
@@ -5,7 +5,7 @@
 
 .media-object-figure {
   margin-right: 1em;
-  flex: 1 0 0;
+  flex: 1.25 0 0;
 }
 
 .media-object-body {


### PR DESCRIPTION
You currently have the date-related include files: `short-date` and `long-date`. Following the existing format, I created `number-date` and implemented it on the home page.
